### PR TITLE
Update README.md in the grid-contrib repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,52 @@
 # grid-contrib
+
+The grid-contrib repository contains contributed software for
+[Hyperledger Grid](https://grid.hyperledger.org), a platform for building
+supply chain solutions that include distributed ledger components.
+
+This repository is intended for community-contributed software, including
+example libraries, data models, and reference implementations for smart
+contracts (also called "transaction families"). This software is designed to
+work with the Hyperledger Grid platform software in the [grid
+repository](https://github.com/hyperledger/grid).
+
+For example, the Grid Track and Trace transaction family provides a smart
+contract that tracks goods as they move through a supply chain. For more
+information, see the [Grid Track and Trace
+documentation](https://grid.hyperledger.org/docs/grid/nightly/master/family_specification.html)
+and the
+[grid/track_and_trace](https://github.com/hyperledger/grid-contrib/tree/master/track_and_trace)
+subdirectory in this repository.
+
+
+## How to Contribute
+
+We welcome contributions to this repository, either as changes to existing
+software or as new example tools and reference implementations. Please follow
+the [guidelines for
+contributing](https://grid.hyperledger.org/community/contributing/). For more
+information, please join the [#grid discussion
+channel](https://chat.hyperledger.org/channel/grid) or [Hyperledger Grid
+mailing list](https://lists.hyperledger.org/g/grid).
+
+
+## More Information
+
+- [Hyperledger Grid website](https://grid.hyperledger.org)
+- [Documentation](https://grid.hyperledger.org/docs/grid/nightly/master/)
+- [Hyperledger Grid mailing list](https://lists.hyperledger.org/g/grid)
+- [#grid discussion channel](https://chat.hyperledger.org/channel/grid)
+- [Hyperledger Grid project overview](https://www.hyperledger.org/projects/grid)
+  at [hyperledger.org](https://www.hyperledger.org)
+
+
+## License
+
+Hyperledger Grid software is licensed under the [Apache License Version
+2.0](LICENSE) software license.
+
+The [Hyperledger Grid
+documentation](https://github.com/hyperledger/grid/tree/master/docs)
+is licensed under a Creative Commons Attribution 4.0 International License
+(CC BY 4.0). You may obtain a copy of the license at
+<http://creativecommons.org/licenses/by/4.0/>.


### PR DESCRIPTION
- Update repo description to explain grid-contrib contents vs grid platform software

- Added description of Grid Track and Trace as an example (with links to the docs
  and source)

- Add "How to Contribute" section with links to website's Contributing page,
  #grid channel and mailing list

- Add "More Information" section with links

- Cleaned up "License" section

Signed-off-by: Anne Chenette <chenette@bitwise.io>