### PR TITLE
Add CONTRIBUTING.md for grid-contrib repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,22 @@
+# Contributing to Hyperledger Grid
+
+Hyperledger Grid is Apache 2.0 licensed and accepts contributions via GitHub
+pull requests.
+
+Contributions from the community help improve the design and capabilities of
+Hyperledger Grid. These contributions are the best way to make a positive impact
+on the project.
+
+This repository contains example domain models, libraries, and reference
+implementations for smart contracts (also called "transaction families").
+We welcome contributors who can:
+
+* Report bugs or issues
+* Add features or enhancements
+* Contribute new examples or smart contract implementations
+* Create or improve tests
+
+For more information, please see
+[Contributing](https://grid.hyperledger.org/community/contributing/)
+on the Hyperledger Grid website.
+


### PR DESCRIPTION
This file provides an overview for contributions and a link to the Contributing page on the Grid website.

Signed-off-by: Anne Chenette <chenette@bitwise.io>