### PR TITLE
Update docker-compose file to work with grid-sdk

### DIFF
--- a/track_and_trace/docker-compose.yaml
+++ b/track_and_trace/docker-compose.yaml
@@ -63,7 +63,8 @@ services:
     image: tnt-tp
     container_name: tnt-tp
     build:
-      context: ../../grid/contracts/track_and_trace
+      context: ../../grid/
+      dockerfile: contracts/track_and_trace/Dockerfile
       args:
         - http_proxy
         - https_proxy


### PR DESCRIPTION
Grid Track and Trace has been updated to work with
the new Grid SDK. This requires that the grid sdk
is available in the docker compose context and the
dockerfile is pointed to explicitly.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>