### PR TITLE
Add sabre smart permission examples

### DIFF
--- a/sabre_smart_permission_examples/.gitignore
+++ b/sabre_smart_permission_examples/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+/**/target/

--- a/sabre_smart_permission_examples/README.md
+++ b/sabre_smart_permission_examples/README.md
@@ -1,0 +1,22 @@
+# Smart Permission Examples
+
+Examples of smart permissions using the Sawtooth Sabre SDK.
+
+[sabre documentation](https://sawtooth.hyperledger.org/docs/sabre/nightly/master/)
+
+# Smart Permission Boilerplate
+
+```
+extern crate sabre_sdk;
+
+use sabre_sdk::{WasmPtr, WasmPtrList, execute_smart_permission_entrypoint, WasmSdkError, Request};
+
+fn has_permission(request: Request) -> Result<bool, WasmSdkError> {
+    // Code describing permission
+}
+
+#[no_mangle]
+pub unsafe fn entrypoint(roles: WasmPtrList, org_id: WasmPtr, public_key: WasmPtr) -> i32 {
+    execute_smart_permission_entrypoint(roles, org_id, public_key, has_permission)
+}
+```

--- a/sabre_smart_permission_examples/intkey/Cargo.toml
+++ b/sabre_smart_permission_examples/intkey/Cargo.toml
@@ -1,0 +1,24 @@
+# Copyright 2018 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[package]
+name = "intkey"
+version = "0.1.0"
+authors = ["Cargill, Incorporated"]
+
+[dependencies]
+sabre-sdk = "0.2.0"
+
+[lib]
+crate-type = ["cdylib"]

--- a/sabre_smart_permission_examples/intkey/src/lib.rs
+++ b/sabre_smart_permission_examples/intkey/src/lib.rs
@@ -1,0 +1,29 @@
+// Copyright 2018 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate sabre_sdk;
+
+use sabre_sdk::{WasmPtr, WasmPtrList, execute_smart_permission_entrypoint, WasmSdkError, Request};
+
+fn has_permission(request: Request) -> Result<bool, WasmSdkError> {
+    Ok(request
+        .get_roles()
+        .iter()
+        .any(|x| x == "admin"))
+}
+
+#[no_mangle]
+pub unsafe fn entrypoint(roles: WasmPtrList, org_id: WasmPtr, payload: WasmPtr, public_key: WasmPtr) -> i32 {
+    execute_smart_permission_entrypoint(roles, org_id, public_key, payload, has_permission)
+}

--- a/sabre_smart_permission_examples/proposal_permission/Cargo.toml
+++ b/sabre_smart_permission_examples/proposal_permission/Cargo.toml
@@ -1,0 +1,24 @@
+# Copyright 2018 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[package]
+name = "proposal_permission"
+version = "0.1.0"
+authors = ["Cargill, Incorporated"]
+
+[dependencies]
+sabre-sdk = "0.2.0"
+
+[lib]
+crate-type = ["cdylib"]

--- a/sabre_smart_permission_examples/proposal_permission/src/lib.rs
+++ b/sabre_smart_permission_examples/proposal_permission/src/lib.rs
@@ -1,0 +1,30 @@
+// Copyright 2018 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate sabre_sdk;
+
+use sabre_sdk::{WasmPtr, WasmPtrList, execute_smart_permission_entrypoint, WasmSdkError, Request};
+
+/// Uses agent role to decide in a proposal can be created.
+fn has_permission(request: Request) -> Result<bool, WasmSdkError> {
+    Ok(request
+       .get_roles()
+       .iter()
+       .any(|x| x == "proposal_creation"))
+}
+
+#[no_mangle]
+pub unsafe fn entrypoint(roles: WasmPtrList, org_id: WasmPtr, payload: WasmPtr, public_key: WasmPtr) -> i32 {
+    execute_smart_permission_entrypoint(roles, org_id, public_key, payload, has_permission)
+}

--- a/sabre_smart_permission_examples/white_list_permission/Cargo.toml
+++ b/sabre_smart_permission_examples/white_list_permission/Cargo.toml
@@ -1,0 +1,26 @@
+# Copyright 2018 Cargill Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[package]
+name = "white_list_permission"
+version = "0.1.0"
+authors = ["Cargill, Incorporated"]
+
+[dependencies]
+protobuf = "2"
+sabre-sdk = "0.2.0"
+grid-sdk = { git = "https://github.com/hyperledger/grid" }
+
+[lib]
+crate-type = ["cdylib"]

--- a/sabre_smart_permission_examples/white_list_permission/src/lib.rs
+++ b/sabre_smart_permission_examples/white_list_permission/src/lib.rs
@@ -1,0 +1,52 @@
+// Copyright 2018 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern crate sabre_sdk;
+extern crate grid_sdk;
+
+use sabre_sdk::{WasmPtr, WasmPtrList, execute_smart_permission_entrypoint, WasmSdkError, Request};
+use grid_sdk::protos::pike_state::AgentList;
+use grid_sdk::protos::track_and_trace_payload::CreateProposalAction;
+
+/// Agents have a single white listed agent they can send
+/// proposals to.
+///
+fn has_permission(request: Request) -> Result<bool, WasmSdkError> {
+    let proposal = protobuf::parse_from_bytes::<CreateProposalAction>(&request.get_payload::<Vec<u8>>())?;
+    let receiving_agent = proposal.get_receiving_agent();
+
+    let agent_bytes = request.get_state(request.get_org_id())?.unwrap();
+
+    let agents = protobuf::parse_from_bytes::<AgentList>(&agent_bytes)?;
+
+    let agent = agents
+        .get_agents()
+        .to_vec()
+        .into_iter()
+        .find(|agent| agent.get_public_key() == request.get_public_key());
+
+    if let Some(a) = agent {
+        Ok(a.get_metadata()
+           .to_vec()
+           .iter()
+           .any(|x| x.get_key() == "white_list_agent" && x.get_value() == receiving_agent))
+    } else {
+        Ok(false)
+    }
+}
+
+#[no_mangle]
+pub unsafe fn entrypoint(roles: WasmPtrList, org_id: WasmPtr, public_key: WasmPtr, payload: WasmPtr) -> i32 {
+    execute_smart_permission_entrypoint(roles, org_id, public_key, payload, has_permission)
+}


### PR DESCRIPTION
Adds examples of Sabre Smart Permissions.

Signed-off-by: Ryan Banks <rbanks@bitwise.io>