### PR TITLE
Move inactive maintainers to emeritus status

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,18 +4,19 @@
 | Name | GitHub |
 | --- | --- |
 | Andi Gunderson | agunde406 |
-| Anne Chenette | chenette |
-| Dan Middleton | dcmiddle |
-| Darian Plumb | dplumb94 |
-| Dave Cecchi | davececchi |
-| James Mitchell | jsmitchell |
 | Peter Schwarz | peterschwarz |
-| Richard Berg | rberg2 |
-| Ryan Banks | RyanLassigBanks |
-| Ryan Beck-Buysse | rbuysse |
 | Shawn Amundson | vaporos |
 
 ### Retired Maintainers
 | Name | GitHub |
 | --- | --- |
+| Anne Chenette | chenette |
 | Boyd Johnson | boydjohnson |
+| Dan Middleton | dcmiddle |
+| Darian Plumb | dplumb94 |
+| Dave Cecchi | davececchi |
+| James Mitchell | jsmitchell |
+| Richard Berg | rberg2 |
+| Ryan Banks | RyanLassigBanks |
+| Ryan Beck-Buysse | rbuysse |
+


### PR DESCRIPTION
The TOC approved a requirement that maintainers
that have not been active in over three to six
months be move to emeritus status.

These maintainers have not been active in over
one year.

hyperledger/toc#32

Signed-off-by: Ry Jones <ry@linux.com>